### PR TITLE
Support disable metal buffer cache to prevent performance degradation caused by large memory caching #390

### DIFF
--- a/mlx/backend/metal/allocator.cpp
+++ b/mlx/backend/metal/allocator.cpp
@@ -23,6 +23,16 @@ void* Buffer::raw_ptr() {
 
 namespace metal {
 
+static bool cache_enabled_ = true;
+
+bool cache_enabled() {
+  return cache_enabled_;
+}
+
+void set_cache_enabled(bool enabled) {
+  cache_enabled_ = enabled;
+}
+
 namespace {
 
 BufferCache::BufferCache(MTL::Device* device)
@@ -196,7 +206,11 @@ Buffer MetalAllocator::malloc(size_t size, bool allow_swap /* = false */) {
 
 void MetalAllocator::free(Buffer buffer) {
   auto buf = static_cast<MTL::Buffer*>(buffer.ptr());
-  buffer_cache_.recycle_to_cache(buf);
+  if (cache_enabled()) {
+    buffer_cache_.recycle_to_cache(buf);
+  } else {
+    buf->release();
+  }
 }
 
 MetalAllocator& allocator() {

--- a/mlx/backend/metal/metal.h
+++ b/mlx/backend/metal/metal.h
@@ -19,6 +19,9 @@ constexpr bool is_available() {
 #endif
 }
 
+bool cache_enabled(void);
+void set_cache_enabled(bool enabled);
+
 void new_stream(Stream stream);
 std::shared_ptr<void> new_scoped_memory_pool();
 

--- a/python/src/metal.cpp
+++ b/python/src/metal.cpp
@@ -11,4 +11,6 @@ using namespace mlx::core;
 void init_metal(py::module_& m) {
   py::module_ metal = m.def_submodule("metal", "mlx.metal");
   metal.def("is_available", &metal::is_available);
+  metal.def("cache_enabled", &metal::cache_enabled, "check if metal buffer cache is enabled, default is true");
+  metal.def("set_cache_enabled", &metal::set_cache_enabled, "enable or disable metal buffer cache");
 }

--- a/python/src/metal.cpp
+++ b/python/src/metal.cpp
@@ -11,6 +11,12 @@ using namespace mlx::core;
 void init_metal(py::module_& m) {
   py::module_ metal = m.def_submodule("metal", "mlx.metal");
   metal.def("is_available", &metal::is_available);
-  metal.def("cache_enabled", &metal::cache_enabled, "check if metal buffer cache is enabled, default is true");
-  metal.def("set_cache_enabled", &metal::set_cache_enabled, "enable or disable metal buffer cache");
+  metal.def(
+      "cache_enabled",
+      &metal::cache_enabled,
+      "check if metal buffer cache is enabled, default is true");
+  metal.def(
+      "set_cache_enabled",
+      &metal::set_cache_enabled,
+      "enable or disable metal buffer cache");
 }

--- a/tests/metal_tests.cpp
+++ b/tests/metal_tests.cpp
@@ -5,6 +5,7 @@
 
 #include "mlx/backend/metal/device.h"
 #include "mlx/backend/metal/metal.h"
+#include "mlx/backend/metal/allocator.h"
 #include "mlx/mlx.h"
 
 using namespace mlx::core;
@@ -470,4 +471,44 @@ TEST_CASE("test metal validation") {
   eval(argmax(x));
 
   eval(scatter_max(array(1), {}, array(2), std::vector<int>{}));
+}
+
+TEST_CASE("test metal enable/disable cache") {
+  // Test enable metal cache
+  {
+    metal::set_cache_enabled(true);
+    CHECK(metal::cache_enabled());
+
+    auto &a = metal::allocator();
+    auto size = 100;
+    auto buf = a.malloc(size, false);
+    
+    // Release a
+    a.free(buf);
+    
+    // Check size should equals to size
+    CHECK_EQ(static_cast<MTL::Buffer*>(buf.ptr())->length(), size);
+  }
+    
+  // Test disable metal cache
+  {
+    metal::set_cache_enabled(false);
+    CHECK(!metal::cache_enabled());
+
+    auto &a = metal::allocator();
+    auto size = 100;
+    auto buf = a.malloc(size, false);
+    auto buf_ptr = static_cast<MTL::Buffer*>(buf.ptr());
+    unsigned char first_byte = *reinterpret_cast<unsigned char*>(buf_ptr);
+    printf("first byte: %d\n", first_byte);
+    
+    // Release a
+    a.free(buf);
+    
+    // If release successfully, the first byte should be different from the first byte before release
+    unsigned char new_first_byte = *reinterpret_cast<unsigned char*>(buf_ptr);
+    printf("new first byte: %d\n", new_first_byte);
+    
+    CHECK_NE(new_first_byte, first_byte);
+  }
 }


### PR DESCRIPTION
Reason for this PR:

When running LLMs inference on devices with smaller memory, such as 8G, the speed noticeably decreases after more and more tokens, and the system performs a large number of Swap memory operations.
I observed that when inferring a 1.6B model with a token length of 100, the current consumption in Activity Monitor increased from an initial 3.19GB to around 4GB, and when the token length reached 500, it increased to around 10GB, Even if the reasoning is stopped and all returned results are deleted, the memory usage will not decrease.
image 3. This is not normal because I observed that the fluctuation of GPU memory on 4090 using the same inference code is only a few tens of MB. 4. By looking into the mlx source code, I found that the metal backend of mlx does not release the memory directly when it manages the buffer cache release, and reserves the memory as cache for subsequent tasks to use when allocating memory, but due to a large number of lazy tasks in the inferencing, it accumulates a large number of memory allocations, which leads to the overall memory occupation is too large(maybe). 5. So this change simply adds a getter method and a setter method for `cache_enabled` under the namespace `mlx.core.metal`, in order to maintain compatibility with older versions, it is set to `False` by default. 6. After disabled metal caches by `mlx.core.metal.set_cache_enabled(False)`, even when reasoning with a token length of 1000, the memory growth is only a few tens of MB and the speed does not decrease significantly(~13 tokens/sec on Macmini M1 8GB).
This will make it possible to run coder LLMs or other LLMs by mlx on macOS, supporting longer inference token lengths and becoming more useful.

Checklist
Put an x in the boxes that apply.

 I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
 I have run pre-commit run --all-files to format my code / installed pre-commit prior to committing changes
 I have added tests that prove my fix is effective or that my feature works
 I have updated the necessary documentation (if needed)